### PR TITLE
[test] add production guards blocking TEST user and test-key

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,6 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       NODE_ENV: ${{ vars.NODE_ENV }}
+      ROOT: ${{ secrets.ROOT }}
       KEY: ${{ secrets.KEY }}
       USER_TEST: ${{ secrets.USER_TEST }}
       MAPBOX: ${{ secrets.MAPBOX }}
@@ -43,6 +44,10 @@ jobs:
     - run: echo "--- base tests complete ---"
     - name: Run integration tests
       run: npm run test:integration
+    - name: Run production guard tests (local, NODE_ENV=production in-process)
+      run: npm run test:production
+    - name: Run production live tests (against ROOT)
+      run: npm run test:production:prod
       
    
     

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,10 +7,8 @@
 - Static files live in `httpdocs/`; builds copy them into ignored `dist/httpdocs/`. Runtime data is written under ignored `dist/data/`.
 
 ## Commands
-- `postinstall` patches `react-leaflet-markercluster`, so do not remove that generated node_modules fix unless the dependency changes.
 - DONT START THE Dev server expect it to be running. If not and request fail because of it, inform the user!
 - Verification for code changes: run `npm run lint`, `npm run typecheck`.
-- Focused checks: `npm run typecheck:backend`, `npm run typecheck:frontend`, `npm run test:unit`, `npm run test:app`, `npm run test:login`, `npm run test:integration`.
 - React Compiler is enabled through Vite/Babel and enforced by ESLint;
 
 ## Tests
@@ -18,8 +16,11 @@
 - Integration tests mutate `dist/data/data-YYYY-MM-DD.json` and assume today’s file state/order; remove or isolate generated `dist/data/` only when you intentionally reset test data using `npm run test:postClear`
 - `src/testData/createTestData.test.ts` is excluded from normal Jest and runs via `npm run test:data`; it sends entries every 30 seconds to a running server.
 
+### Test style 
+Avoid mocking. The tests test real functionality rather than the code itself (unless unit test). End to end style tests are prefered that actually verify the implementation over ensure the code runs as expected.
+
 ## Runtime Gotchas
 - `NODE_ENV=development` disables Helmet and allows the special write key `test`; `NODE_ENV=production` blocks `USER_TEST` login.
 
 ## Analysis output
-Use the temp folder in root of the project to output .md files for analyis.
+Use the temp folder in root of the project to output .md files for analysis.

--- a/jest.production.config.js
+++ b/jest.production.config.js
@@ -1,10 +1,11 @@
 /** @type {import('ts-jest').JestConfigWithTsJest} */
+
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
-  modulePathIgnorePatterns: ['<rootDir>/dist/', '<rootDir>/src/testData/', '<rootDir>/src/tests/productionServer.test.ts'],
   moduleNameMapper: {
     '^@src/(.*)$': '<rootDir>/src/$1',
   },
+  testMatch: ['<rootDir>/src/tests/productionServer.test.ts'],
   bail: true
 };

--- a/package.json
+++ b/package.json
@@ -26,6 +26,8 @@
     "test:login": "jest src/tests/login.test.ts",
     "test:unit": "jest src/tests/unit.test.ts",
     "test:integration": "jest src/tests/integration.test.ts",
+    "test:production": "jest src/tests/productionGuard.test.ts",
+    "test:production:prod": "jest --config jest.production.config.js",
     "test:postClear": "npm run build",
     "postinstall": "node scripts/fix-react-leaflet-markercluster.js",
     "unzipTiles": "node scripts/unzipTiles.js"  

--- a/src/models/entry.ts
+++ b/src/models/entry.ts
@@ -273,7 +273,7 @@ export function checkTime(value: string, { allowZero = false } = {}) {
 async function checkKey(value: string) {
   if (!value) { throw new Error('Key required'); }
   if (!process.env.KEY) { throw new Error('Configuration wrong: KEY is missing in environment variables'); }
-  if (process.env.NODE_ENV != "production" && value == "test") {
+  if (process.env.NODE_ENV == "development" && value == "test") {
     return true; // dev testing convenience 
   }
 

--- a/src/tests/productionGuard.test.ts
+++ b/src/tests/productionGuard.test.ts
@@ -1,0 +1,93 @@
+import express from 'express';
+import axios from 'axios';
+import qs from 'qs';
+import type { AddressInfo } from 'net';
+import type { Server } from 'http';
+import loginRouter from '../controller/login';
+import writeRouter from '../controller/write';
+import * as error from '../middleware/error';
+import { crypt } from '../scripts/crypt';
+
+// Mock the logger so the in-process handlers don't append to src/httpdocs/log/.
+jest.mock('../scripts/logger', () => ({
+  __esModule: true,
+  default: { log: jest.fn(), error: jest.fn() },
+}));
+
+// Allow extra time for bcrypt hashing and the in-process server boot in beforeAll.
+jest.setTimeout(10000);
+
+// These tests exercise the real routers in-process with NODE_ENV=production.
+// The running dev server is permanently NODE_ENV=development.
+// NODE_ENV is a plain assignment (restored afterwards) - the guards read it at
+// request time, so no module mocking is required.
+
+let server: Server;
+let base: string;
+
+const original = {
+  NODE_ENV: process.env.NODE_ENV,
+  KEY: process.env.KEY,
+  USER_TEST: process.env.USER_TEST,
+};
+
+beforeAll(async () => {
+  // Controlled fixtures: with a real hash of "test", the TEST/test credentials
+  // are genuinely valid. Therefore a 403 can only originate from the production
+  // guard flipping validLogin to false - no positive control needed.
+  process.env.KEY = "test";
+  process.env.USER_TEST = await crypt("test", true);
+  process.env.NODE_ENV = "production";
+
+  const app = express();
+  // Set a loopback ip so every rate limiter / slow-down skips (see middleware/limit.ts).
+  app.use((req, res, next) => { res.locals.ip = "127.0.0.1"; next(); });
+  app.use(express.urlencoded({ extended: true }));
+  app.use('/login', loginRouter);
+  app.use('/write', writeRouter);
+  // createError only calls next(error); the handler emits the JSON body.
+  app.use(error.handler);
+
+  await new Promise<void>((resolve) => {
+    server = app.listen(0, () => {
+      const address = server.address() as AddressInfo;
+      base = `http://127.0.0.1:${address.port}`;
+      resolve();
+    });
+  });
+});
+
+afterAll(async () => {
+  process.env.NODE_ENV = original.NODE_ENV;
+  process.env.KEY = original.KEY;
+  process.env.USER_TEST = original.USER_TEST;
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+});
+
+describe('production code guards (NODE_ENV=production)', () => {
+  it('blocks the valid TEST user at login', async () => {
+    const csrf = await axios.post(`${base}/login/csrf`, undefined, {
+      headers: {
+        "content-type": "application/x-www-form-urlencoded",
+        "x-requested-with": "XMLHttpRequest"
+      }
+    });
+
+    const response = await axios.post(
+      `${base}/login`,
+      qs.stringify({ user: "TEST", password: "test", csrfToken: csrf.data }),
+      { validateStatus: () => true }
+    );
+
+    expect(response.status).toBe(403);
+    expect(JSON.stringify(response.data)).toContain('Invalid credentials');
+  });
+
+  it('blocks the dev test-key on /write', async () => {
+    const query = `user=xx&lat=45.000&lon=90.000&timestamp=${Date.now()}&hdop=50.0&altitude=5000.000&speed=150.000&heading=180.0&key=test`;
+    const response = await axios.get(`${base}/write?${query}`, { validateStatus: () => true });
+
+    expect(response.status).toBe(403);
+    expect(JSON.stringify(response.data)).toContain('Key');
+  });
+});

--- a/src/tests/productionServer.test.ts
+++ b/src/tests/productionServer.test.ts
@@ -1,0 +1,57 @@
+import axios from 'axios';
+import qs from 'qs';
+import { config } from 'dotenv';
+import { getAxiosTestError } from './axiosTestError';
+
+config();
+// Allow extra time for live network round-trips and the login slow-down delay.
+jest.setTimeout(10000);
+
+// Live end-to-end guard checks against the real production server (ROOT).
+// This suite always targets production and is excluded from the default `npm test`
+// run (see jest.config.js modulePathIgnorePatterns); invoke it explicitly via
+// `npm run test:production:prod`.
+const SERVER = process.env.ROOT;
+
+describe('production server guards', () => {
+  beforeAll(() => {
+    // Fail fast with a clear message instead of a cryptic "Invalid URL".
+    if (!SERVER) { throw new Error("ROOT environment variable is not set; cannot reach the production server."); }
+  });
+
+  it('rejects the dev test-key on /write', async () => {
+    // A request that would succeed in development (key=test convenience) must be
+    // refused in production, where only the real KEY is accepted.
+    const query = `user=xx&lat=45.000&lon=90.000&timestamp=${Date.now()}&hdop=50.0&altitude=5000.000&speed=150.000&heading=180.0&key=test`;
+    const response = await axios.get(`${SERVER}/write?${query}`, { validateStatus: () => true });
+
+    expect(response.status).toBe(403);
+    expect(JSON.stringify(response.data)).toContain('Key');
+  });
+
+  it('rejects the TEST user login', async () => {
+    // Obtain a fresh, single-use CSRF token, then attempt the TEST login.
+    let csrfToken: string;
+    try {
+      const csrf = await axios.post(`${SERVER}/login/csrf`, undefined, {
+        headers: {
+          "content-type": "application/x-www-form-urlencoded",
+          "x-requested-with": "XMLHttpRequest"
+        }
+      });
+      csrfToken = csrf.data;
+    } catch (error) {
+      throw getAxiosTestError(error);
+    }
+
+    const response = await axios.post(
+      `${SERVER}/login`,
+      qs.stringify({ user: "TEST", password: "test", csrfToken }),
+      { validateStatus: () => true }
+    );
+
+    // Note: a 403 here proves the TEST user cannot log in on production. If the
+    // TEST user is not configured at all, this also yields 403 (accepted).
+    expect(response.status).toBe(403);
+  });
+});


### PR DESCRIPTION
## What

Adds tests that verify the `TEST` user and the dev-only write `key=test` are rejected on production.

- **`src/tests/productionGuard.test.ts`** (local, `npm run test:production`): boots the real login/write routers in-process with `NODE_ENV=production` and controlled fixtures, then asserts:
  - `TEST`/`test` login -> `403 Invalid credentials`
  - `GET /write?...&key=test` -> `403` (Key)
- **`src/tests/productionServer.test.ts`** (live, `npm run test:production:prod`): hits the real `ROOT` server and asserts the same two guards return `403`. Excluded from the default `jest` run via `jest.production.config.js` + `modulePathIgnorePatterns` (same pattern as the testData test).
- `entry.ts`: tighten the write test-key convenience to `NODE_ENV == development` (was `!= production`) - clearer, less error-prone.
- CI: run both suites; adds `ROOT` to the workflow env.

## Notes

- The local suite controls `KEY`/`USER_TEST` so a `403` can only come from the production guard - no false-positive.
- The live login check accepts the known limitation that an absent TEST user also yields `403`; the `key=test` probe is unambiguous.