### PR TITLE
maxSpeed split: warning/alert severity (#327)

### DIFF
--- a/src/client/components/Map.tsx
+++ b/src/client/components/Map.tsx
@@ -14,7 +14,6 @@ import 'leaflet/dist/leaflet.css';
 import 'react-leaflet-markercluster/styles'
 import "../css/map.css";
 import { LayerChangeHandler } from "./LayoutChangeHandler";
-import { exceed } from "../scripts/maxSpeed";
 import { MapHideSmallCluster } from "./MapHideSmallCluster";
 import { MapZoomLimit } from "./MapZoomLimit";
 import { usePopup } from "../hooks/usePopup";
@@ -39,7 +38,8 @@ function Map({ entries }: { entries: Array<Models.IEntry> }) {
 		const iconSize = className != "none" ? 22 : 14;
 		className = (Date.now() - entry.time.recieved) <= 60000 ? "animate " + className : className; // when entry is recent append animate class
 
-		exceed(entry) ? className += " maxSpeed " : "";
+		if (entry.speed.maxSpeed?.alert) { className += " maxSpeed alert"; }
+		else if (entry.speed.maxSpeed?.warning) { className += " maxSpeed warning"; }
 
 		return { className, iconSize }
 	}, [cleanEntries, lastEntry]);

--- a/src/client/components/Popup_speed.tsx
+++ b/src/client/components/Popup_speed.tsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import { exceed } from "../scripts/maxSpeed"
 
 export default function PopupSpeed({ entry }: { entry: Models.IEntry }) {
   return (
@@ -25,10 +24,10 @@ export default function PopupSpeed({ entry }: { entry: Models.IEntry }) {
         </>
       )}
       
-      {entry.speed.maxSpeed && (
+      {typeof entry.speed.maxSpeed?.value === "number" && (
         <>
           <dt>MaxSpeed</dt>
-          <dd><span className={exceed(entry) ? "alert" : ""}>{`${(entry.speed.maxSpeed).toFixed(1)} km/h`}</span></dd>
+          <dd><span className={entry.speed.maxSpeed.alert ? "alert" : entry.speed.maxSpeed.warning ? "main" : ""}>{`${entry.speed.maxSpeed.value.toFixed(1)} km/h`}</span></dd>
         </>
       )}
     </>

--- a/src/client/css/map.css
+++ b/src/client/css/map.css
@@ -119,6 +119,10 @@
 		color: var(--alert);
 	}
 
+	.main {
+		color: var(--main);
+	}
+
 	.actions {
 		display: flex;
 		justify-content: flex-end;
@@ -259,7 +263,16 @@
 		}
 	}
 
-	& .icon.maxSpeed {
+	& .icon.maxSpeed.warning {
+		svg {
+			--fillColor: var(--main);
+		}
+		&.none svg {
+			--strokeColor: var(--main);
+		}
+	}
+
+	& .icon.maxSpeed.alert {
 		svg {
 			--fillColor: var(--alert);
 		}

--- a/src/client/scripts/maxSpeed.ts
+++ b/src/client/scripts/maxSpeed.ts
@@ -3,5 +3,5 @@ export const getMaxSpeed = function (cleanEntries: Models.IEntry[]) {
 		// compare the current entry's GPS speed with the maxSpeed found so far
 		return Math.max(maxSpeed, entry.speed.gps);
 	}, cleanEntries[0].speed.gps);
-	return maxSpeed *= 3.6; // convert M/S to KM/h	
+	return maxSpeed *= 3.6; // convert M/S to KM/h
 };

--- a/src/client/scripts/maxSpeed.ts
+++ b/src/client/scripts/maxSpeed.ts
@@ -5,17 +5,3 @@ export const getMaxSpeed = function (cleanEntries: Models.IEntry[]) {
 	}, cleanEntries[0].speed.gps);
 	return maxSpeed *= 3.6; // convert M/S to KM/h	
 };
-
-export const exceed = function (entry: Models.IEntry) {
-	if (!entry.speed.maxSpeed) { return false; }
-	let compareSpeed:number;
-	const currentSpeed = entry.speed.gps * 3.6;
-	const calcSpeed = entry.speed.total ? entry.speed.total * 3.6 : null;
-
-	const harmonicMean:number = calcSpeed ? 2 * (currentSpeed * calcSpeed) / (currentSpeed + calcSpeed) : 0; // Harmonic Mean;
-
-	compareSpeed = Math.floor(Math.max(currentSpeed, harmonicMean));
-	compareSpeed = Math.floor(compareSpeed - entry.hdop);
-	
-	return compareSpeed > entry.speed.maxSpeed;
-};

--- a/src/client/tests/components.test.tsx
+++ b/src/client/tests/components.test.tsx
@@ -145,7 +145,7 @@ function statusEntry(index: number, values: {
 		ignore: values.ignore ?? false,
 		eta: values.eta,
 		eda: values.eda,
-		speed: { gps: values.gps, horizontal: values.horizontal, vertical: 0, total: values.horizontal, maxSpeed: 100 },
+		speed: { gps: values.gps, horizontal: values.horizontal, vertical: 0, total: values.horizontal, maxSpeed: { value: 100, warning: false, alert: false } },
 		distance: { horizontal: values.horizontalDist, vertical: values.verticalDist, total: values.horizontalDist },
 		time: { created: Date.now(), recieved: Date.now(), uploadDuration: values.upload, diff: values.diff, createdString: '12:00' },
 	});

--- a/src/client/tests/popups.test.tsx
+++ b/src/client/tests/popups.test.tsx
@@ -58,25 +58,28 @@ describe('PopupInfo', () => {
 
 describe('PopupSpeed', () => {
 	it('converts gps speed to km/h and shows the calculated row only with a total', () => {
-		render(<PopupSpeed entry={makeEntry({ speed: { gps: 10, horizontal: 0, vertical: 0, total: 20, maxSpeed: 100 } })} />);
+		render(<PopupSpeed entry={makeEntry({ speed: { gps: 10, horizontal: 0, vertical: 0, total: 20, maxSpeed: { value: 100, warning: false, alert: false } } })} />);
 
 		expect(screen.getByText('Calculated').nextElementSibling).toHaveTextContent('72.0 km/h'); // 20 * 3.6
 		expect(screen.getByText('GPS').nextElementSibling).toHaveTextContent('36.0 km/h'); // 10 * 3.6
 	});
 
 	it('omits the calculated row when there is no total speed', () => {
-		render(<PopupSpeed entry={makeEntry({ speed: { gps: 10, horizontal: 0, vertical: 0, total: 0, maxSpeed: 100 } })} />);
+		render(<PopupSpeed entry={makeEntry({ speed: { gps: 10, horizontal: 0, vertical: 0, total: 0, maxSpeed: { value: 100, warning: false, alert: false } } })} />);
 
 		expect(screen.queryByText('Calculated')).not.toBeInTheDocument();
 	});
 
-	it('alerts the max-speed row only when the entry exceeds the limit', () => {
-		// 28.5 m/s -> 102.6 km/h -> floor 102 - hdop 1 -> 101 > 100 (mirrors exceed() in scripts.test)
-		const speeding = render(<PopupSpeed entry={makeEntry({ hdop: 1, speed: { gps: 28.5, horizontal: 0, vertical: 0, total: 0, maxSpeed: 100 } })} />);
-		expect(within(speeding.container).getByText('100.0 km/h')).toHaveClass('alert');
+	it('classes the max-speed row by the precomputed severity, alert taking precedence over warning', () => {
+		const alerting = render(<PopupSpeed entry={makeEntry({ speed: { gps: 28.5, horizontal: 0, vertical: 0, total: 0, maxSpeed: { value: 100, warning: true, alert: true } } })} />);
+		expect(within(alerting.container).getByText('100.0 km/h')).toHaveClass('alert');
 
-		const cruising = render(<PopupSpeed entry={makeEntry({ hdop: 1, speed: { gps: 10, horizontal: 0, vertical: 0, total: 0, maxSpeed: 100 } })} />);
+		const warning = render(<PopupSpeed entry={makeEntry({ speed: { gps: 28.5, horizontal: 0, vertical: 0, total: 0, maxSpeed: { value: 100, warning: true, alert: false } } })} />);
+		expect(within(warning.container).getByText('100.0 km/h')).toHaveClass('main');
+
+		const cruising = render(<PopupSpeed entry={makeEntry({ speed: { gps: 10, horizontal: 0, vertical: 0, total: 0, maxSpeed: { value: 100, warning: false, alert: false } } })} />);
 		expect(within(cruising.container).getByText('100.0 km/h')).not.toHaveClass('alert');
+		expect(within(cruising.container).getByText('100.0 km/h')).not.toHaveClass('main');
 	});
 });
 

--- a/src/client/tests/scripts.test.ts
+++ b/src/client/tests/scripts.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it } from 'vitest';
 import { timeAgo } from '../scripts/timeAgo';
 import { getDistance } from '../scripts/getDistance';
-import { exceed, getMaxSpeed } from '../scripts/maxSpeed';
+import { getMaxSpeed } from '../scripts/maxSpeed';
 import { convertJwt } from '../scripts/convertJwt';
 import { layers } from '../scripts/layers';
 import { makeEntry, makeFakeJwt } from './testUtils';
@@ -124,7 +124,7 @@ describe('getDistance', () => {
 
 describe('getMaxSpeed', () => {
 	const gpsEntry = (gps: number): Models.IEntry =>
-		makeEntry({ speed: { gps, horizontal: 0, vertical: 0, total: 0, maxSpeed: 100 } });
+		makeEntry({ speed: { gps, horizontal: 0, vertical: 0, total: 0, maxSpeed: { value: 100, warning: false, alert: false } } });
 
 	it('returns the highest gps speed converted to km/h', () => {
 		const entries = [gpsEntry(10), gpsEntry(25), gpsEntry(15)];
@@ -138,41 +138,6 @@ describe('getMaxSpeed', () => {
 		const expectedKmh = 36; // 10 m/s * 3.6
 
 		expect(getMaxSpeed(entries)).toBeCloseTo(expectedKmh, 9);
-	});
-});
-
-describe('exceed', () => {
-	const speedEntry = (gps: number, maxSpeed: number, total = 0, hdop = 1): Models.IEntry =>
-		makeEntry({ speed: { gps, horizontal: 0, vertical: 0, total, maxSpeed }, hdop });
-
-	it('returns false when no maxSpeed limit is known', () => {
-		const noLimit = speedEntry(30, 0);
-
-		expect(exceed(noLimit)).toBe(false);
-	});
-
-	it('returns true when the floored, hdop-reduced speed exceeds the limit', () => {
-		// 28.5 m/s -> 102.6 km/h -> floor 102 -> minus hdop 1 -> 101 > 100
-		const justAboveLimit = speedEntry(28.5, 100);
-
-		expect(exceed(justAboveLimit)).toBe(true);
-	});
-
-	it('returns false when the reduced speed only reaches the limit', () => {
-		// 28.2 m/s -> 101.52 km/h -> floor 101 -> minus hdop 1 -> 100, not above 100
-		const exactlyAtLimit = speedEntry(28.2, 100);
-
-		expect(exceed(exactlyAtLimit)).toBe(false);
-	});
-
-	it('uses the harmonic mean of gps and total speed when total is present', () => {
-		// gps alone: 97.2 km/h -> floor 97 -> minus hdop 1 -> 96, below the limit
-		const gpsOnly = speedEntry(27, 100);
-		// harmonic mean of 97.2 and 108 km/h is ~102.3 -> floor 102 -> minus hdop 1 -> 101 > 100
-		const withTotal = speedEntry(27, 100, 30);
-
-		expect(exceed(gpsOnly)).toBe(false);
-		expect(exceed(withTotal)).toBe(true);
 	});
 });
 

--- a/src/client/tests/testUtils.tsx
+++ b/src/client/tests/testUtils.tsx
@@ -123,7 +123,7 @@ export const makeEntry = (overrides: Partial<Models.IEntry> = {}): Models.IEntry
 	time: { created: Date.now(), recieved: Date.now(), uploadDuration: 0.5, diff: 30, createdString: '12:00' },
 	angle: 45,
 	distance: { horizontal: 0, vertical: 0, total: 0 },
-	speed: { gps: 0, horizontal: 0, vertical: 0, total: 0, maxSpeed: 100 },
+	speed: { gps: 0, horizontal: 0, vertical: 0, total: 0, maxSpeed: { value: 100, warning: false, alert: false } },
 	address: 'Test Street, Test Town',
 	...overrides,
 });

--- a/src/models/entry.ts
+++ b/src/models/entry.ts
@@ -26,8 +26,12 @@ let lastWrittenToFile = 0;
   if the original entry had a maxSpeed limit set.
 */
 function restoreMaxSpeedSeverity(e: Models.IEntry, originalEntry: Models.IEntry): void {
-  if (originalEntry.speed?.maxSpeed) {
-    e.speed.maxSpeed = getMaxSpeedSeverity(e, originalEntry.speed.maxSpeed.value);
+  const maxSpeed = originalEntry.speed?.maxSpeed;
+  // Guard against pre-existing persisted entries where maxSpeed is still a plain number
+  // (from before this field became an object) - skip rather than recompute against `.value`
+  // being undefined, which would otherwise silently store a false "not speeding" result.
+  if (maxSpeed && typeof maxSpeed === "object") {
+    e.speed.maxSpeed = getMaxSpeedSeverity(e, maxSpeed.value);
   }
 }
 

--- a/src/models/entry.ts
+++ b/src/models/entry.ts
@@ -10,6 +10,7 @@ import { getIgnore, getIgnoreClose } from '@src/scripts/ignore';
 import logger from '@src/scripts/logger';
 import { getAddressData } from "@src/scripts/getAddressData";
 import { getPath, updateWithPathData } from "@src/scripts/getPath";
+import { getMaxSpeedSeverity } from "@src/scripts/maxSpeed";
 
 /*
   This variable is used for race conditions
@@ -17,6 +18,18 @@ import { getPath, updateWithPathData } from "@src/scripts/getPath";
   In case another request is faster than the previous one, the slower one will be ignored.
 */
 let lastWrittenToFile = 0;
+
+/*
+  getSpeed() returns a brand new ISpeed object with no maxSpeed field.
+  Whenever recalculate() reassigns e.speed via getSpeed(...), this restores
+  the severity (recomputed against the entry's possibly-changed speed/neighbor)
+  if the original entry had a maxSpeed limit set.
+*/
+function restoreMaxSpeedSeverity(e: Models.IEntry, originalEntry: Models.IEntry): void {
+  if (originalEntry.speed?.maxSpeed) {
+    e.speed.maxSpeed = getMaxSpeedSeverity(e, originalEntry.speed.maxSpeed.value);
+  }
+}
 
 export const entry = {
   recalculate: (entries: Models.IEntry[], index: number, direction?: "before" | "after"): Models.IEntry[] => {
@@ -65,6 +78,7 @@ export const entry = {
           ? newDistance
           : { ...newDistance, path: originalEntry.distance?.path };
         e.speed = getSpeed(e.speed.gps, e);
+        restoreMaxSpeedSeverity(e, originalEntry);
         if (!neighborChanged) { e.speed.path = originalEntry.speed?.path; }
 
         if (neighborChanged && e.path) {
@@ -88,10 +102,12 @@ export const entry = {
             // Preserve path-related properties, clear only relational ones
             e.distance = { horizontal: 0, vertical: 0, total: 0, path: originalEntry.distance?.path };
             const speed = getSpeed(e.speed.gps);
-            e.speed = { ...speed, path: originalEntry.speed?.path, maxSpeed: originalEntry.speed?.maxSpeed };
+            e.speed = { ...speed, path: originalEntry.speed?.path };
+            restoreMaxSpeedSeverity(e, originalEntry);
           } else {
             e.distance = { horizontal: 0, vertical: 0, total: 0 };
             e.speed = getSpeed(e.speed.gps);
+            restoreMaxSpeedSeverity(e, originalEntry);
             if (e.path) {
               e.path = { hasFetched: e.path.hasFetched, ignore: true, ignoreReason: "♻ Neighbor changed due to manual ignore" };
               e.time = { ...e.time, path: undefined };
@@ -184,7 +200,7 @@ export const entry = {
 
     entry.address = address;
     if (maxSpeed) {
-      entry.speed.maxSpeed = maxSpeed;
+      entry.speed.maxSpeed = getMaxSpeedSeverity(entry, maxSpeed);
     }
 
     if (pathData) {

--- a/src/scripts/maxSpeed.ts
+++ b/src/scripts/maxSpeed.ts
@@ -1,0 +1,24 @@
+/**
+ * Ported from the former client-side `exceed()` in src/client/scripts/maxSpeed.ts.
+ * Computes the severity (warning/alert) of exceeding a location's legal speed limit,
+ * using an hdop-based margin to account for GPS inaccuracy.
+ */
+
+// hdop margin multiplier for the lower/"main" (warning) threshold
+const HDOP_MULTIPLIER_WARNING = 1.5;
+// hdop margin multiplier for the higher/"alert" threshold
+const HDOP_MULTIPLIER_ALERT = 1;
+// additional buffer (km/h) added on top of the limit for the alert threshold
+const ALERT_SPEED_BUFFER_KMH = 10;
+
+export function getMaxSpeedSeverity(entry: { speed: { gps: number, total?: number }, hdop: number }, limit: number): Models.IMaxSpeed {
+  const currentSpeed = entry.speed.gps * 3.6;
+  const calcSpeed = entry.speed.total ? entry.speed.total * 3.6 : null;
+  const harmonicMean = calcSpeed ? 2 * (currentSpeed * calcSpeed) / (currentSpeed + calcSpeed) : 0; // Harmonic Mean
+  const raw = Math.floor(Math.max(currentSpeed, harmonicMean));
+
+  const alert = Math.floor(raw - entry.hdop * HDOP_MULTIPLIER_ALERT) > limit + ALERT_SPEED_BUFFER_KMH;
+  const warning = alert || Math.floor(raw - entry.hdop * HDOP_MULTIPLIER_WARNING) > limit;
+
+  return { value: limit, warning, alert };
+}

--- a/src/tests/integration.test.ts
+++ b/src/tests/integration.test.ts
@@ -642,6 +642,44 @@ describe('entry.recalculate: maxSpeed severity happy path', () => {
 
     expect(result[2].speed.maxSpeed).toEqual(expectedMaxSpeed);
   });
+
+  it('leaves legacy numeric maxSpeed alone instead of storing a false "not speeding" result', () => {
+    // Entries written before this feature persist speed.maxSpeed as a plain number.
+    // Simulate that on-disk shape surviving into a recalculate() pass (e.g. an entry
+    // whose neighbor gets ignored before it's ever rewritten by create()).
+    const legacyLimit = 50;
+
+    const first = makeEntry({ index: 0, lat: 52.00000, lon: 13.00000 });
+
+    const middle = makeEntry({
+      index: 1,
+      lat: 52.01000,
+      lon: 13.00000,
+      time: { created: 15000, recieved: 0, uploadDuration: 0, createdString: "" },
+      speed: { gps: 5, horizontal: 0, vertical: 0, total: 0 },
+    });
+
+    const last = makeEntry({
+      index: 2,
+      lat: 52.02246,
+      lon: 13.00000,
+      time: { created: 30000, recieved: 0, uploadDuration: 0, createdString: "" },
+      speed: {
+        gps: 20,
+        horizontal: 0,
+        vertical: 0,
+        total: 0,
+        maxSpeed: legacyLimit as unknown as Models.IMaxSpeed, // pre-migration on-disk shape
+      },
+    });
+
+    const result = entry.recalculate([first, middle, last], 1);
+
+    // Must not become `{ value: undefined, warning: false, alert: false }` - that would
+    // read as a confidently-computed "under the limit", which is wrong: severity was
+    // never actually evaluated for this legacy value.
+    expect(result[2].speed.maxSpeed).toBeUndefined();
+  });
 });
 
 describe('API calls', () => {

--- a/src/tests/integration.test.ts
+++ b/src/tests/integration.test.ts
@@ -3,6 +3,11 @@ import fs from "fs";
 import path from "path";
 import qs from "qs";
 import { axiosTestRequest, getAxiosTestError, requestStatus } from './axiosTestError';
+import { entry } from '../models/entry';
+import { getDistance } from '../scripts/distance';
+import { getTime } from '../scripts/time';
+import { getSpeed } from '../scripts/speed';
+import { getMaxSpeedSeverity } from '../scripts/maxSpeed';
 
 const date = new Date();
 const formattedDate = `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')}`;
@@ -545,6 +550,99 @@ describe('read/ignore', () => {
   });
 });
 
+
+describe('entry.recalculate: maxSpeed severity happy path', () => {
+  /*
+    A true end-to-end /write -> Nominatim -> /read/ignore test can't reliably assert on a real
+    maxSpeed limit: getAddressData() hits the live OpenStreetMap Nominatim API and throttles
+    requests to 1 per 4s (see src/scripts/getAddressData.ts), so the returned legal speed limit
+    for any given coordinate can't be pinned down or mocked in this test file (no jest.mock is
+    set up here, and none of the other tests in this file rely on Nominatim's maxSpeed data —
+    see the Race Condition test's `expect(entry.speed.maxSpeed).toBe(undefined)` below).
+    Instead this exercises entry.recalculate() directly -- the same function used by the
+    /read/ignore route -- against entries carrying a preset speed.maxSpeed limit, to verify the
+    severity is correctly recomputed (not dropped or left stale) once a neighbor is marked ignored
+    and the entry's derived total speed changes as a result.
+  */
+  const makeEntry = (overrides: Partial<Models.IEntry>): Models.IEntry => ({
+    altitude: 0,
+    hdop: 2,
+    heading: 0,
+    index: 0,
+    lat: 0,
+    lon: 0,
+    user: "TE",
+    ignore: false,
+    eta: 0,
+    eda: 0,
+    time: { created: 0, recieved: 0, uploadDuration: 0, createdString: "" },
+    angle: 0,
+    distance: { horizontal: 0, vertical: 0, total: 0 },
+    speed: { gps: 0, horizontal: 0, vertical: 0, total: 0 },
+    address: "",
+    ...overrides,
+  });
+
+  it('recomputes maxSpeed severity for the new neighbor after a middle entry is ignored', () => {
+    const limit = 80; // km/h
+
+    const first = makeEntry({
+      index: 0,
+      lat: 52.00000,
+      lon: 13.00000,
+      time: { created: 0, recieved: 0, uploadDuration: 0, createdString: "" },
+    });
+
+    const middle = makeEntry({
+      index: 1,
+      lat: 52.01000,
+      lon: 13.00000,
+      time: { created: 15000, recieved: 0, uploadDuration: 0, createdString: "" },
+      speed: { gps: 5, horizontal: 0, vertical: 0, total: 0 },
+    });
+
+    const last = makeEntry({
+      index: 2,
+      lat: 52.02246,
+      lon: 13.00000,
+      time: { created: 30000, recieved: 0, uploadDuration: 0, createdString: "" },
+      speed: {
+        gps: 20, // moderate own gps speed, comfortably under the limit on its own
+        horizontal: 0,
+        vertical: 0,
+        total: 0,
+        // preset as already stored (e.g. computed at write-time against the short middle->last leg):
+        // comfortably under the limit, to prove the recompute below actually changes it
+        maxSpeed: { value: limit, warning: false, alert: false },
+      },
+    });
+
+    const entries = [first, middle, last];
+
+    // Ignore the middle entry -> `last`'s neighbor changes from `middle` to `first`,
+    // a much longer hop covered in the same time, driving its derived total speed up.
+    const result = entry.recalculate(entries, 1);
+
+    expect(result[1].ignore).toBe(true);
+    expect(result[0].ignore).toBe(false);
+    expect(result[2].ignore).toBe(false);
+
+    // Independently compute the expected severity using the same pure helpers recalculate()
+    // uses internally (each already covered by their own unit tests), applied to the new
+    // first->last hop, to verify entry.ts's wiring recomputes (rather than drops/carries over) it.
+    const expectedDistance = getDistance(last, first);
+    const expectedTime = getTime(last.time.created, first, last.time);
+    const expectedSpeed = getSpeed(last.speed.gps, { ...last, time: expectedTime, distance: expectedDistance });
+    const expectedMaxSpeed = getMaxSpeedSeverity({ speed: expectedSpeed, hdop: last.hdop }, limit);
+
+    // Sanity check that this scenario is meaningful: the recomputed severity should indeed
+    // have flipped from the preset "false/false" to "true/true", proving recalculation happened.
+    expect(expectedMaxSpeed.warning).toBe(true);
+    expect(expectedMaxSpeed.alert).toBe(true);
+
+    expect(result[2].speed.maxSpeed).toEqual(expectedMaxSpeed);
+  });
+});
 
 describe('API calls', () => {
   test(`1000 api calls`, async () => {

--- a/src/tests/unit.test.ts
+++ b/src/tests/unit.test.ts
@@ -2,6 +2,7 @@ import { checkNumber, checkTime } from "../models/entry";
 import toFixedNumber from "../scripts/toFixedNumber";
 import { checkPreconditions, reorderCoordinates } from "../scripts/getPath";
 import { getIgnoreClose } from "../scripts/ignore";
+import { getMaxSpeedSeverity } from "../scripts/maxSpeed";
 
 
 describe("entry checkNumber", () => {
@@ -91,8 +92,7 @@ describe("getPath", () => {
         "gps": 0,
         "horizontal": 0,
         "vertical": 0,
-        "total": 1,
-        "maxSpeed": 0
+        "total": 1
       },
       "address": "nowhere"
     }
@@ -145,7 +145,7 @@ describe("getIgnoreClose", () => {
     time: { created: 0, recieved: 0, uploadDuration: 0, diff: 30, createdString: "00:00" },
     angle: 0,
     distance: { horizontal: 0, vertical: 0, total: 0 },
-    speed: { gps: 0, horizontal: 0, vertical: 0, total: 0, maxSpeed: 0 },
+    speed: { gps: 0, horizontal: 0, vertical: 0, total: 0 },
     address: ""
   };
 
@@ -181,5 +181,45 @@ describe("getIgnoreClose", () => {
   it("returns false when diagonal distance slightly exceeds threshold", () => {
     // dist1 ~22m, entry.hdop=2 gives a 22m threshold.
     expect(getIgnoreClose(at(0, 0), at(hdopOffset, hdopOffset), at(hdopOffset * 2, hdopOffset * 2, 2))).toBe(false);
+  });
+});
+
+describe("getMaxSpeedSeverity", () => {
+  const speedEntry = (gps: number, hdop: number, total?: number) => ({
+    speed: { gps, total },
+    hdop
+  });
+
+  it("returns warning=false, alert=false when comfortably under the limit", () => {
+    // 10 m/s -> 36 km/h, hdop=1, limit=100
+    const entry = speedEntry(10, 1);
+    expect(getMaxSpeedSeverity(entry, 100)).toEqual({ value: 100, warning: false, alert: false });
+  });
+
+  it("returns warning=true, alert=false when moderately exceeding the limit", () => {
+    // 29 m/s -> 104.4 km/h -> floor 104
+    // alert: floor(104 - 1*1) = 103, not > limit+10 (110) -> false
+    // warning: floor(104 - 1*1.5) = 102, > limit (100) -> true
+    const entry = speedEntry(29, 1);
+    expect(getMaxSpeedSeverity(entry, 100)).toEqual({ value: 100, warning: true, alert: false });
+  });
+
+  it("returns warning=true AND alert=true when the limit is exceeded by a wide margin, even with a large hdop", () => {
+    // 25.6 m/s -> 92.16 km/h -> floor 92, hdop=30, limit=50
+    // alert: floor(92 - 30*1) = 62, > limit+10 (60) -> true
+    // warning without the "alert ||" fallback: floor(92 - 30*1.5) = 47, NOT > 50 -> would be false
+    // this asserts warning is still forced true via the OR-with-alert construction
+    const entry = speedEntry(25.6, 30);
+    expect(getMaxSpeedSeverity(entry, 50)).toEqual({ value: 50, warning: true, alert: true });
+  });
+
+  it("uses the harmonic mean of gps and total speed when total is present", () => {
+    // gps 27 m/s -> 97.2 km/h, total 33 m/s -> 118.8 km/h
+    // harmonic mean = 2*(97.2*118.8)/(97.2+118.8) = 106.92 -> raw = floor(106.92) = 106
+    // (without the harmonic mean, raw would be floor(97.2) = 97, and warning would be false)
+    // warning: floor(106 - 1*1.5) = 104, > limit (100) -> true
+    // alert:   floor(106 - 1*1)   = 105, NOT > limit+10 (110) -> false
+    const entry = speedEntry(27, 1, 33);
+    expect(getMaxSpeedSeverity(entry, 100)).toEqual({ value: 100, warning: true, alert: false });
   });
 });

--- a/types.d.ts
+++ b/types.d.ts
@@ -158,6 +158,7 @@ namespace Models {
 		*/
 		alert: boolean
 	}
+
 	interface IDistance {
 		horizontal: number,
 		vertical: number,

--- a/types.d.ts
+++ b/types.d.ts
@@ -138,10 +138,25 @@ namespace Models {
 		vertical?: number,
 		total?: number,
 		/**
-		* maximum allowed speed in km/h
+		* legal speed limit (km/h) at this location plus the severity of exceeding it
 		*/
-		maxSpeed?: number,
+		maxSpeed?: Models.IMaxSpeed,
 		path?: number
+	}
+
+	interface IMaxSpeed {
+		/**
+		* legal speed limit in km/h, as retrieved from map data
+		*/
+		value: number,
+		/**
+		* the limit is clearly exceeded; rendered in the "main" color. Always true when alert is true.
+		*/
+		warning: boolean,
+		/**
+		* the limit is exceeded by a wide margin (10 km/h+); rendered in "alert" red, taking precedence over warning
+		*/
+		alert: boolean
 	}
 	interface IDistance {
 		horizontal: number,


### PR DESCRIPTION
Closes #327.

## Approach
`speed.maxSpeed` changes from a plain number to `{ value, warning, alert }`, computed server-side in the new `src/scripts/maxSpeed.ts` (`getMaxSpeedSeverity`) and wired into `entry.ts` `create()` + `recalculate()`. Client (`Map.tsx`, `Popup_speed.tsx`) just reads the flags now — `alert` (red) takes precedence over `warning` (orange/`main`).

Thresholds: `warning` loosens the old margin to 1.5x hdop; `alert` keeps the original 1x hdop margin but requires exceeding the limit by 10km/h+. `alert` is guaranteed to imply `warning` (`warning = alert || ...`).

## Assumptions to double-check
- "increase the threshold by 1.5 hdop" read as *multiplier* 1.5x (not the old 1x + an extra 1.5x = 2.5x). Easy to flip — see named constants in `src/scripts/maxSpeed.ts`.
- "10km/h + hdop" read as: same 1x-hdop margin as before, plus a flat +10km/h on the limit.
- Fixed a pre-existing bug found while wiring this up: `recalculate()` silently dropped `maxSpeed` (via `getSpeed()` returning a fresh `ISpeed`) for every recalculated entry except one hand-cased branch. Now recomputed correctly for all branches — relevant since ignoring an entry (this base branch's feature) changes neighbors' derived speed.
- No data migration for old persisted entries where `maxSpeed` is still a raw number — `Popup_speed.tsx` guards with `typeof ... === "number"` so it degrades silently instead of crashing; `Map.tsx`/marker styling likewise just won't show a severity class for that old data.
- Integration tests need a running dev server on `localhost:80`, which wasn't reachable in this sandbox — please run `npm run test:integration` locally before merging. All other checks pass: typecheck (all 4 configs), lint, unit (21/21), vitest (71/71 excluding 4 pre-existing env-only failures unrelated to this change).

## Tests
TDD: new/updated unit tests in `src/tests/unit.test.ts` and `src/client/tests/*`, one new integration test in `src/tests/integration.test.ts` covering the recalculate happy path (see in-file comment on why it can't go through a real Nominatim call).